### PR TITLE
Kari/checkout styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -96,3 +96,36 @@ select {
   margin: auto;
   color: #fff;
 }
+
+.checkout_view {
+  padding: 20px;
+}
+
+.checkout_view h2 {
+  text-align: center;
+}
+
+.order_details_box {
+  width: 40%;
+  position: fixed;
+  right: 15%;
+  border: dotted 1px grey;
+  padding: 25px;
+  background-color: #fff;
+}
+
+.order_details_box h3 {
+  display: inline-block;
+}
+
+.shipping_info {
+  clear: both;
+  margin-top: 20px;
+}
+
+.checkout_section {
+  padding-top: 10px;
+  padding-bottom: 20px;
+}
+
+

--- a/app/views/order_items/cart.html.erb
+++ b/app/views/order_items/cart.html.erb
@@ -2,25 +2,19 @@
 
 <% if flash[:success] %>
   <div>
-    <p class="alert alert-success">
-      <%= flash[:success] %>
-    </p>
+    <p class="alert alert-success"><%= flash[:success] %></p>
   </div>
 <% end %>
 
 <% if flash[:notice] %>
   <div>
-    <p class="alert alert-danger">
-      <%= flash[:notice] %>
-    </p>
+    <p class="alert alert-danger"><%= flash[:notice] %></p>
   </div>
 <% end %>
 
 <% if flash[:errors] %>
   <div>
-    <p class="alert alert-danger">
-      <%= flash[:errors] %>
-    </p>
+    <p class="alert alert-danger"><%= flash[:errors] %></p>
   </div>
 <% end %>
 
@@ -28,76 +22,41 @@
 <% if @order && @order.order_items.count > 0 %>
   <table class="table">
     <tr>
-      <th>
-        Item
-      </th>
-      <th>
-        Price
-      </th>
-      <th>
-        Quantity
-      </th>
-      <th>
-        Item total
-      </th>
-      <th>
-        <!-- spacer -->
-      </th>
+      <th>Item</th>
+      <th>Price</th>
+      <th>Quantity</th>
+      <th>Item total</th>
+      <th><!-- spacer --></th>
     </tr>
     <% @order.order_items.each do |order_item| %>
       <% unit_price = order_item.product.price %>
       <tr>
-        <td>
-          <%= link_to order_item.product.name, product_path(order_item.product) %>
-        </td>
-        <td>
-          <%= readable_price(unit_price) %>
-        </td>
+        <td><%= link_to order_item.product.name, product_path(order_item.product) %></td>
+        <td><%= readable_price(unit_price) %></td>
         <td>
           <%= form_for order_item, url: order_item_path(order_item), method: :put do |f| %>
             <%= f.number_field :quantity, in: 1..order_item.product.stock, step: 1, value: order_item.quantity, class: "form-control fit-width" %>
             <%= f.submit 'Update', class: "btn btn-default" %>
-          <% end %>
-        </td>
-        <td>
-          <%= readable_price(unit_price * order_item.quantity) %>
-        </td>
-        <td>
-          <%= link_to 'Remove', order_item_path(order_item), method: :delete, data: { confirm: "Remove this item from your cart?" }, class: "btn btn-danger" %>
-        </td>
+          <% end %></td>
+        <td><%= readable_price(unit_price * order_item.quantity) %></td>
+        <td><%= link_to order_item_path(order_item), method: :delete, data: { confirm: "Remove this item from your cart?" }, class: "btn" do %><span class="glyphicon glyphicon-remove"></span><% end %></td>
       </tr>
     <% end %>
     <tr>
-      <td>
-        <!-- spacer -->
-      </td>
-      <td>
-        <!-- spacer -->
-      </td>
-      <th>
-        Order total:
-      </td>
-      <th>
-        <%= readable_price(@order.subtotal) %>
-      </td>
-      <td>
-        <!-- spacer -->
-      </td>
+      <td><!-- spacer --></td>
+      <td><!-- spacer --></td>
+      <th>Order total:</td>
+      <th><%= readable_price(@order.subtotal) %></td>
+      <td><!-- spacer --></td>
     </tr>
   </table>
 
-  <p>
-    <%= link_to 'Check out', checkout_path, class: "btn btn-success btn-block" %>
-  </p>
-  <p>
-    <%= link_to 'Continue shopping', products_path, class: 'btn btn-primary' %>
-  </p>
+  <p><%= link_to 'Check out', checkout_path, class: "btn btn-success" %></p>
+  <p><%= link_to 'Continue shopping', products_path, class: 'btn btn-primary' %></p>
 
 <% else %>
+  <p>There are no items in your cart.</p>
 
-  <p>
-    There are no items in your cart.
-  </p>
   <%= link_to 'Return to shopping', products_path, class: "btn btn-primary" %>
 
 <% end %>

--- a/app/views/orders/checkout.html.erb
+++ b/app/views/orders/checkout.html.erb
@@ -6,18 +6,14 @@
 
 <% if flash.now[:errors] %>
   <div>
-    <p class="alert alert-danger">
-      <%= flash.now[:errors] %>
-    </p>
+    <p class="alert alert-danger"><%= flash.now[:errors] %></p>
   </div>
 <% end %>
 
 <% if @order.errors.messages.count > 0 %>
   <% @order.errors.full_messages.each do |message| %>
     <div>
-      <p class="alert alert-warning">
-        <%= message %>
-      </p>
+      <p class="alert alert-warning"><%= message %></p>
     </div>
   <% end %>
 <% end %>
@@ -26,33 +22,17 @@
 
 <table class="table">
   <tr>
-    <th>
-      Item
-    </th>
-    <th>
-      Price
-    </th>
-    <th>
-      Quantity
-    </th>
-    <th>
-      Line Price
-    </th>
+    <th>Item</th>
+    <th>Price</th>
+    <th>Quantity</th>
+    <th>Line Price</th>
   </tr>
   <% @order_items.each do |order_item| %>
     <tr>
-      <td>
-        <%= order_item.product.name %>
-      </td>
-      <td>
-        <%= readable_price(order_item.product.price) %>
-      </td>
-      <td>
-        <%= order_item.quantity %>
-      </td>
-      <td>
-        <%= readable_price(order_item.product.price * order_item.quantity) %>
-      </td>
+      <td><%= order_item.product.name %></td>
+      <td><%= readable_price(order_item.product.price) %></td>
+      <td><%= order_item.quantity %></td>
+      <td><%= readable_price(order_item.product.price * order_item.quantity) %></td>
     </tr>
   <% end %>
 </table>
@@ -60,6 +40,8 @@
 <p>Order total: <%= readable_price(@order.subtotal) %></p>
 
 <%= link_to 'Edit order', cart_path, class: "btn btn-warning" %>
+
+<!-- ################################################### -->
 
 <%= form_for @order, url: shipping_path(@order), method: :put, class: "form" do |f| %>
 
@@ -101,44 +83,48 @@
   </div>
 
   <%= f.submit "Calculate Shipping", class: 'btn btn-danger btn-block'%>
+<% end %>
 
-  <% end %>
+<!-- ################################################### -->
 
-  <h3>Shipping Estimates</h3>
+<% if action_name == "shipping" %>
   <%= form_for @order, url: finalize_order_path(@order), method: :put, class: "form" do |f| %>
+    
+    <h3>Shipping Estimates</h3>
 
-  <div class="form-group">
-      <%= f.label :shipping, "Options" %>
-      <%= f.select :shipping, @shipping_options, {include_blank: true}, class: "form-control" %>
-  </div>
+    <div class="form-group">
+        <%= f.label :shipping, "Options" %>
+        <%= f.select :shipping, @shipping_options, {include_blank: true}, class: "form-control" %>
+    </div>
 
-  <h3>Payment</h3>
+    <h3>Payment</h3>
 
-  <div class="form-group">
-    <%= f.label :cc_name, "Name on card" %>
-    <%= f.text_field :cc_name, required: true, class: 'form-control' %>
-  </div>
+    <div class="form-group">
+      <%= f.label :cc_name, "Name on Card" %>
+      <%= f.text_field :cc_name, required: true, class: 'form-control' %>
+    </div>
 
-  <div class="form-group">
-    <%= f.label :cc_number, "Card number" %>
-    <%= f.text_field :cc_number, required: true, class: 'form-control' %>
-  </div>
+    <div class="form-group">
+      <%= f.label :cc_number, "Card Number" %>
+      <%= f.text_field :cc_number, required: true, class: 'form-control' %>
+    </div>
 
-  <div class="form-group">
-    <%= f.label :cc_expiration, "Credit card expiration date", class: "form-label" %>
-    <%= f.date_select :cc_expiration, use_month_numbers: true, use_two_digit_numbers: true, order: [:month, :year], start_year: Date.today.year, start_month: Date.today.month, end_year: Date.today.year+10, prompt: true, required: true, class: 'form-control' %>
-  </div>
+    <div class="form-group">
+      <%= f.label :cc_expiration, "Credit Card Expiration Date", class: "form-label" %>
+      <%= f.date_select :cc_expiration, use_month_numbers: true, use_two_digit_numbers: true, order: [:month, :year], start_year: Date.today.year, start_month: Date.today.month, end_year: Date.today.year+10, prompt: true, required: true, class: 'form-control' %>
+    </div>
 
-  <div class="form-group">
-    <%= f.label :cc_cvv, "CVV (3 digit code on back of card)" %>
-    <%= f.text_field :cc_cvv, maxlength: 3, required: true, class: 'form-control' %>
-  </div>
+    <div class="form-group">
+      <%= f.label :cc_cvv, "CVV (3 digit code on back of card)" %>
+      <%= f.text_field :cc_cvv, maxlength: 3, required: true, class: 'form-control' %>
+    </div>
 
-  <div class="form-group">
-    <%= f.label :billing_zip, "Billing zip code" %>
-    <%= f.text_field :billing_zip, maxlength: 5, required: true, class: 'form-control' %>
-  </div>
+    <div class="form-group">
+      <%= f.label :billing_zip, "Billing Zip Code" %>
+      <%= f.text_field :billing_zip, maxlength: 5, required: true, class: 'form-control' %>
+    </div>
 
     <%= f.submit "Place order", class: 'btn btn-danger btn-block'%>
 
+  <% end %>
 <% end %>

--- a/app/views/orders/checkout.html.erb
+++ b/app/views/orders/checkout.html.erb
@@ -1,130 +1,151 @@
-<h2>Finalize order</h2>
+<section class="checkout_view">
+  <h2>Finalize Order</h2>
 
-<p>
-  <%= link_to "Not ready to buy? Return to shopping...", products_path, class: "btn btn-primary btn-block" %>
-</p>
+  <%= link_to "Return to Shopping", products_path, class: "btn btn-primary" %>
 
-<% if flash.now[:errors] %>
-  <div>
-    <p class="alert alert-danger"><%= flash.now[:errors] %></p>
-  </div>
-<% end %>
-
-<% if @order.errors.messages.count > 0 %>
-  <% @order.errors.full_messages.each do |message| %>
+  <% if flash.now[:errors] %>
     <div>
-      <p class="alert alert-warning"><%= message %></p>
+      <p class="alert alert-danger"><%= flash.now[:errors] %></p>
     </div>
   <% end %>
-<% end %>
 
-<h3>Order details:</h3>
-
-<table class="table">
-  <tr>
-    <th>Item</th>
-    <th>Price</th>
-    <th>Quantity</th>
-    <th>Line Price</th>
-  </tr>
-  <% @order_items.each do |order_item| %>
-    <tr>
-      <td><%= order_item.product.name %></td>
-      <td><%= readable_price(order_item.product.price) %></td>
-      <td><%= order_item.quantity %></td>
-      <td><%= readable_price(order_item.product.price * order_item.quantity) %></td>
-    </tr>
+  <% if @order.errors.messages.count > 0 %>
+    <% @order.errors.full_messages.each do |message| %>
+      <div>
+        <p class="alert alert-warning"><%= message %></p>
+      </div>
+    <% end %>
   <% end %>
-</table>
 
-<p>Order total: <%= readable_price(@order.subtotal) %></p>
+<!-- ################################################### -->
+  <div class="order_details_box">
+    <h3>Order Details</h3><%= link_to cart_path, class: "btn" do %><span class="glyphicon glyphicon-pencil"></span><% end %>
 
-<%= link_to 'Edit order', cart_path, class: "btn btn-warning" %>
+    <table class="table">
+      <tr>
+        <th>Item</th>
+        <th>Price</th>
+        <th>Quantity</th>
+        <th>Line Price</th>
+      </tr>
+      <% @order_items.each do |order_item| %>
+        <tr>
+          <td><%= order_item.product.name %></td>
+          <td><%= readable_price(order_item.product.price) %></td>
+          <td><%= order_item.quantity %></td>
+          <td><%= readable_price(order_item.product.price * order_item.quantity) %></td>
+        </tr>
+        <tr>
+          <td></td>
+          <td></td>
+          <td>Selected Shipping</td>
+          <td>$ -----</td>
+        </tr>
+        <tr>
+          <td></td>
+          <td></td>
+          <td><strong>TOTAL:</strong></td>
+          <td><strong><%= readable_price(@order.subtotal) %></strong></td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+
 
 <!-- ################################################### -->
 
-<%= form_for @order, url: shipping_path(@order), method: :put, class: "form" do |f| %>
+  <div class="shipping_info">
+    <%= form_for @order, url: shipping_path(@order), method: :put, class: "form" do |f| %>
+      <h3>Customer Information</h3>
 
-  <h3>Shipping</h3>
+      <div class="form-group">
+        <%= f.label :mailing_name, "Full name" %>
+        <%= f.text_field :mailing_name, required: true, class: 'form-control' %>
+      </div>
 
-  <div class="form-group">
-    <%= f.label :mailing_name, "Full name" %>
-    <%= f.text_field :mailing_name, required: true, class: 'form-control' %>
+      <div class="form-group">
+        <%= f.label :email %>
+        <%= f.text_field :email, required: true, class: 'form-control' %>
+      </div>
+
+      <h3>Shipping Address</h3>
+
+      <div class="form-group">
+        <%= f.label :address1, "Address line 1" %>
+        <%= f.text_field :address1, required: true, class: 'form-control' %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :address2, "Address line 2" %>
+        <%= f.text_field :address2, class: 'form-control' %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :city %>
+        <%= f.text_field :city, required: true, class: 'form-control' %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :state, class: "form-label" %>
+        <%= f.select :state, Order::US_STATES, { include_blank: true }, { class: 'form-control' } %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :mailing_zip, "Zip code" %>
+        <%= f.text_field :mailing_zip, maxlength: 5, required: true, class: 'form-control' %>
+      </div>
+
+      <%= f.submit "Calculate Shipping", class: 'btn btn-danger'%>
+    <% end %>
   </div>
 
-  <div class="form-group">
-    <%= f.label :email %>
-    <%= f.text_field :email, required: true, class: 'form-control' %>
-  </div>
+  <!-- ################################################### -->
+  <% if action_name == "shipping" %>
+    <%= form_for @order, url: finalize_order_path(@order), method: :put, class: "form" do |f| %>
+      
+      <hr>
+      <div id="shipping_info">
+        <div class="checkout_section">
+          <h3>Shipment Method</h3>
 
-  <div class="form-group">
-    <%= f.label :address1, "Address line 1" %>
-    <%= f.text_field :address1, required: true, class: 'form-control' %>
-  </div>
+          <div class="form-group">
+              <%= f.label :shipping, "Carrier Options" %>
+              <%= f.select :shipping, @shipping_options, {include_blank: true}, class: "form-control" %>
+          </div>
+        </div>
 
-  <div class="form-group">
-    <%= f.label :address2, "Address line 2" %>
-    <%= f.text_field :address2, class: 'form-control' %>
-  </div>
+        <hr>
+        <div class="checkout_section">
+          <h3>Payment Information</h3>
 
-  <div class="form-group">
-    <%= f.label :city %>
-    <%= f.text_field :city, required: true, class: 'form-control' %>
-  </div>
+          <div class="form-group">
+            <%= f.label :cc_name, "Name on Card" %>
+            <%= f.text_field :cc_name, required: true, class: 'form-control' %>
+          </div>
 
-  <div class="form-group">
-    <%= f.label :state, class: "form-label" %>
-    <%= f.select :state, Order::US_STATES, { include_blank: true }, { class: 'form-control' } %>
-  </div>
+          <div class="form-group">
+            <%= f.label :cc_number, "Card Number" %>
+            <%= f.text_field :cc_number, required: true, class: 'form-control' %>
+          </div>
 
-  <div class="form-group">
-    <%= f.label :mailing_zip, "Zip code" %>
-    <%= f.text_field :mailing_zip, maxlength: 5, required: true, class: 'form-control' %>
-  </div>
+          <div class="form-group">
+            <%= f.label :cc_expiration, "Credit Card Expiration Date", class: "form-label" %>
+            <%= f.date_select :cc_expiration, use_month_numbers: true, use_two_digit_numbers: true, order: [:month, :year], start_year: Date.today.year, start_month: Date.today.month, end_year: Date.today.year+10, prompt: true, required: true, class: 'form-control' %>
+          </div>
 
-  <%= f.submit "Calculate Shipping", class: 'btn btn-danger btn-block'%>
-<% end %>
+          <div class="form-group">
+            <%= f.label :cc_cvv, "CVV (3 digit code on back of card)" %>
+            <%= f.text_field :cc_cvv, maxlength: 3, required: true, class: 'form-control' %>
+          </div>
 
-<!-- ################################################### -->
+          <div class="form-group">
+            <%= f.label :billing_zip, "Billing Zip Code" %>
+            <%= f.text_field :billing_zip, maxlength: 5, required: true, class: 'form-control' %>
+          </div>
 
-<% if action_name == "shipping" %>
-  <%= form_for @order, url: finalize_order_path(@order), method: :put, class: "form" do |f| %>
-    
-    <h3>Shipping Estimates</h3>
-
-    <div class="form-group">
-        <%= f.label :shipping, "Options" %>
-        <%= f.select :shipping, @shipping_options, {include_blank: true}, class: "form-control" %>
-    </div>
-
-    <h3>Payment</h3>
-
-    <div class="form-group">
-      <%= f.label :cc_name, "Name on Card" %>
-      <%= f.text_field :cc_name, required: true, class: 'form-control' %>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :cc_number, "Card Number" %>
-      <%= f.text_field :cc_number, required: true, class: 'form-control' %>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :cc_expiration, "Credit Card Expiration Date", class: "form-label" %>
-      <%= f.date_select :cc_expiration, use_month_numbers: true, use_two_digit_numbers: true, order: [:month, :year], start_year: Date.today.year, start_month: Date.today.month, end_year: Date.today.year+10, prompt: true, required: true, class: 'form-control' %>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :cc_cvv, "CVV (3 digit code on back of card)" %>
-      <%= f.text_field :cc_cvv, maxlength: 3, required: true, class: 'form-control' %>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :billing_zip, "Billing Zip Code" %>
-      <%= f.text_field :billing_zip, maxlength: 5, required: true, class: 'form-control' %>
-    </div>
-
-    <%= f.submit "Place order", class: 'btn btn-danger btn-block'%>
-
+          <%= f.submit "Place order", class: 'btn btn-danger'%>
+        </div>
+      </div>
+    <% end %>
   <% end %>
-<% end %>
+</section>


### PR DESCRIPTION
Adjusted some styling on 'cart' view

Styling for 'checkout' view that includes:
-Order details box is fixed to the right so you can always see it as you scroll down
-Editing styling of buttons, headers, section dividers
-2nd half of form fields populate after you click on 'calculate shipping' (so you can't checkout before you've populated that field.
